### PR TITLE
Makefileからmakedepsの呼び出しと関連処理を削除

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for TemplateApp iOS Project
 # 
-# [ユーザー向けコマンド]
+# [ユーザ向けコマンド]
 # --- Xcodeの操作 ---
 #   make boot                - ローカルシミュレータ（iPhone 16 Pro）を起動
 #   make run-debug           - デバッグビルドを作成し、ローカルシミュレータにインストール、起動

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@
 #   make test-all            - 全テストを実行
 #
 # [内部ワークフロー用コマンド]
-#   make deps                - 依存関係をチェック
 #   make find-test-artifacts - テストの成果物探索
 #
 # === Configuration ===
@@ -207,14 +206,6 @@ ui-test:
 .PHONY: test-all
 test-all: find-test-artifacts unit-test ui-test
 	@echo "✅ All tests completed."
-
-# === Dependencies check ===
-.PHONY: deps
-deps:
-	@echo "🔍 Checking dependencies..."
-	@command -v mint >/dev/null 2>&1 || { echo "❌ Error: Mint not installed. Please install: brew install mint"; exit 1; }
-	@command -v xcbeautify >/dev/null 2>&1 || { echo "❌ Error: xcbeautify not installed. Please install: brew install xcbeautify"; exit 1; }
-	@echo "✅ All required dependencies are available."
 
 # === Find existing artifacts ===
 .PHONY: find-test-artifacts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Makefileから依存関係チェック用のターゲット（deps）とその参照を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->